### PR TITLE
Fix issues with local setup

### DIFF
--- a/src/tools/Scoop/Install-NugetPackageToCache.ps1
+++ b/src/tools/Scoop/Install-NugetPackageToCache.ps1
@@ -40,7 +40,7 @@ function Install-NugetPackageToCache
             Install-NugetPackage `
                 -PackageId $PackageId `
                 -Version $Version `
-                -OutputLocation $cacheLocation
+                -OutputLocation $cacheLocation | Out-Null
         }
         
         return $cacheLocation

--- a/src/tools/Scoop/Install-Sitecore.ps1
+++ b/src/tools/Scoop/Install-Sitecore.ps1
@@ -59,7 +59,7 @@ function Install-Sitecore
                 {
                     $ExistingFolder = (Test-Path $webPath) -and ((ls $webPath).Count -gt 0)
 
-                    if($ExistingFolder -and -not ($Backup -or -$Force)) {
+                    if($ExistingFolder -and -not ($Backup -or $Force)) {
                         Write-Warning "Web folder $webPath already exists and Force is false. Nothing will be done."
                         return
                     }

--- a/src/tools/Scoop/Install-Sitecore.ps1
+++ b/src/tools/Scoop/Install-Sitecore.ps1
@@ -57,7 +57,7 @@ function Install-Sitecore
 
                 try
                 {
-                    $ExistingFolder = Test-Path $webPath -and (ls $webPath).Count -gt 0
+                    $ExistingFolder = (Test-Path $webPath) -and ((ls $webPath).Count -gt 0)
 
                     if($ExistingFolder -and -not ($Backup -or -$Force)) {
                         Write-Warning "Web folder $webPath already exists and Force is false. Nothing will be done."


### PR DESCRIPTION
When Install-NugetPackageToCache was called the first time for a package, the output of the nuget command corrupted the return value which should only be the location of the created cache.