### PR TITLE
Speed up build time with ensure "WinVerifyTrust" isn't triggered for each project and file while building projects

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -3,10 +3,10 @@ NUGET
     Microsoft.Web.Xdt (2.1.1)
     Pester (4.0.8)
     Unic.Bob.Keith (2.0.2)
-    Unic.Bob.Rubble (3.1)
+    Unic.Bob.Rubble (3.2)
     Unic.Bob.Scratch (0.2)
-    Unic.Bob.Skip (4.0.4)
-    Unic.Bob.Wendy (3.0.1)
+    Unic.Bob.Skip (4.0.5)
+    Unic.Bob.Wendy (3.2)
 GITHUB
   remote: adoprog/Sitecore-PowerCore
     Framework/DBUtils/DBUtils.psm1 (038a01b42ea3f681fb8d05f3444d363d99f4d9ac)

--- a/src/tools/Scoop/Scoop.psm1
+++ b/src/tools/Scoop/Scoop.psm1
@@ -22,7 +22,7 @@ else {
 
 $partentPath = (Get-Item $PSScriptRoot).Parent.FullName
 
-Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude "*.Tests.ps1" | Foreach-Object{ . $_.FullName }
+Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude "*.Tests.ps1" | Foreach-Object{ . ([scriptblock]::Create([io.file]::ReadAllText($_.FullName))) }
 Export-ModuleMember -Function * -Alias *
 
 Import-Module (ResolvePath "Unic.Bob.Wendy" "tools\Wendy") -Force


### PR DESCRIPTION
Since few weeks we faced the issue that projects are built much slower then usually. This is a fix for that.